### PR TITLE
chore: bump version to 0.0.2

### DIFF
--- a/src/_meta.lua
+++ b/src/_meta.lua
@@ -14,7 +14,7 @@ return {
     name = 'karakeep',
     fullname = _('Karakeep'),
     description = _([[Read and bookmark links in your Karakeep instance.]]),
-    version = '0.0.1',
+    version = '0.0.2',
     author = 'Algus Dark',
     repo_owner = 'AlgusDark',
     repo_name = 'karakeep.koplugin',


### PR DESCRIPTION
Release of fix for always show the dialog to save to karakeep, doesn't matter it's device capability to open links